### PR TITLE
Update to mysql2 library

### DIFF
--- a/shackServer/index.ts
+++ b/shackServer/index.ts
@@ -41,7 +41,7 @@ app.use("/data", dataRouter);
 app.use("/schedule", scheduleRouter);
 
 // Error handling middleware
-app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+app.use((err: Error, req: Request, res: Response) => {
   console.error(err.stack, req.originalUrl);
   res.status(500).send("Something went wrong!");
 });

--- a/shackServer/index.ts
+++ b/shackServer/index.ts
@@ -4,8 +4,6 @@ import dotenv from "dotenv";
 import dataRouter from "./src/data";
 import scheduleRouter from "./src/schedule";
 import RateLimit from "express-rate-limit";
-import swaggerUi from "swagger-ui-express";
-import swaggerDocument from "./swagger-output.json";
 
 const limiter = RateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
@@ -17,7 +15,6 @@ dotenv.config();
 const app = express();
 export const PORT = process.env.PORT || 1783;
 
-app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 app.use(limiter);
 app.use(cors());
 app.use(express.json());
@@ -44,7 +41,7 @@ app.use("/data", dataRouter);
 app.use("/schedule", scheduleRouter);
 
 // Error handling middleware
-app.use((err: Error, req: Request, res: Response) => {
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
   console.error(err.stack, req.originalUrl);
   res.status(500).send("Something went wrong!");
 });

--- a/shackServer/package.json
+++ b/shackServer/package.json
@@ -10,12 +10,10 @@
     "swagger": "node ./swagger.ts"
   },
   "dependencies": {
-    "@types/mysql": "^2.15.25",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-rate-limit": "^7.2.0",
-    "mysql": "^2.18.1",
     "mysql2": "^3.15.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.0"

--- a/shackServer/package.json
+++ b/shackServer/package.json
@@ -16,6 +16,7 @@
     "express": "^4.18.2",
     "express-rate-limit": "^7.2.0",
     "mysql": "^2.18.1",
+    "mysql2": "^3.15.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.0"
   },

--- a/shackServer/src/data.ts
+++ b/shackServer/src/data.ts
@@ -1,12 +1,12 @@
 import express, { Request, Response, NextFunction } from "express";
 import { shackLogItem } from "../models";
 const db = require("./db");
-import { MysqlError } from "mysql";
+import { QueryError } from "mysql2";
 const router = express.Router();
 
 // Reusable function for executing database queries
 function executeQuery(query: string, res: Response) {
-  db.query(query, function (err: MysqlError | null, result: shackLogItem[]) {
+  db.query(query, function (err: QueryError | null, result: shackLogItem[]) {
     if (err) {
       console.error(err);
       return res.status(500).send("Internal Server Error");

--- a/shackServer/src/db.ts
+++ b/shackServer/src/db.ts
@@ -1,4 +1,4 @@
-const mysql = require("mysql");
+const mysql = require("mysql2/promise");
 import dotenv from "dotenv";
 
 dotenv.config();
@@ -8,6 +8,8 @@ const connection = mysql.createPool({
   user: process.env.MYSQL_USER,
   password: process.env.MYSQL_PASSWORD,
   database: process.env.MYSQL_DATABASE,
+  waitForConnections: true,
+  connectionLimit: 10,
 });
 
 module.exports = connection;

--- a/shackServer/src/db.ts
+++ b/shackServer/src/db.ts
@@ -1,4 +1,4 @@
-const mysql = require("mysql2/promise");
+const mysql = require("mysql2");
 import dotenv from "dotenv";
 
 dotenv.config();

--- a/shackServer/src/schedule.ts
+++ b/shackServer/src/schedule.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response } from "express";
 import { SQLUpdateResponse, ShackSchedule } from "../models";
 var db = require("./db");
-import { MysqlError } from "mysql";
+import { QueryError } from "mysql2";
 const router = express.Router();
 
 router.use(express.json());
@@ -11,7 +11,7 @@ router.get("/", function (req: Request, res: Response) {
   // #swagger.tags = ['Schedule']
   const query =
     "SELECT start_hour, duration, id FROM shackSchedule ORDER BY start_hour";
-  db.query(query, function (err: MysqlError | null, result: ShackSchedule[]) {
+  db.query(query, function (err: QueryError | null, result: ShackSchedule[]) {
     if (err) {
       console.error(err);
       res.status(500).send("Internal Server Error");
@@ -28,7 +28,7 @@ router.post("/update", function (req: Request, res: Response) {
   db.query(
     query,
     [start_hour, duration, id],
-    function (err: MysqlError | null) {
+    function (err: QueryError | null) {
       if (err) {
         console.error(err);
         res.status(500).send("Internal Server Error");
@@ -38,7 +38,7 @@ router.post("/update", function (req: Request, res: Response) {
       db.query(
         selectQuery,
         id,
-        function (err: MysqlError | null, result: ShackSchedule[]) {
+        function (err: QueryError | null, result: ShackSchedule[]) {
           if (err) {
             console.error(err);
             res.status(500).send("Internal Server Error");
@@ -58,7 +58,7 @@ router.post("/add", function (req: Request, res: Response) {
   db.query(
     query,
     [start_hour, duration],
-    function (err: MysqlError | null, resp: SQLUpdateResponse) {
+    function (err: QueryError | null, resp: SQLUpdateResponse) {
       if (err) {
         console.error(err);
         res.status(500).send("Internal Server Error");
@@ -68,7 +68,7 @@ router.post("/add", function (req: Request, res: Response) {
       db.query(
         selectQuery,
         resp.insertId,
-        function (err: MysqlError | null, result: ShackSchedule[]) {
+        function (err: QueryError | null, result: ShackSchedule[]) {
           if (err) {
             console.error(err);
             res.status(500).send("Internal Server Error");
@@ -88,7 +88,7 @@ router.post("/delete", function (req: Request, res: Response) {
   db.query(
     query,
     id,
-    function (err: MysqlError | null, resp: SQLUpdateResponse) {
+    function (err: QueryError | null, resp: SQLUpdateResponse) {
       if (err) {
         console.error(err);
         res.status(500).send("Internal Server Error");

--- a/shackServer/yarn.lock
+++ b/shackServer/yarn.lock
@@ -439,6 +439,11 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
+aws-ssl-profiles@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz#157dd77e9f19b1d123678e93f120e6f193022641"
+  integrity sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -662,6 +667,11 @@ define-data-property@^1.1.1:
     gopd "^1.0.1"
     has-property-descriptors "^1.0.0"
 
+denque@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
+  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
+
 depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -864,6 +874,13 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
+generate-function@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.3.1.tgz#f069617690c10c868e73b8465746764f97c3479f"
+  integrity sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==
+  dependencies:
+    is-property "^1.0.2"
+
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.2.tgz#281b7622971123e1ef4b3c90fd7539306da93f3b"
@@ -981,6 +998,13 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.0.tgz#c50cd80e6746ca8115eb98743afa81aa0e147a3e"
+  integrity sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 ignore@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
@@ -1034,6 +1058,11 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-property@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+  integrity sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -1124,12 +1153,27 @@ lodash.mergewith@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
   integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
+long@^5.2.1:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru-cache@^7.14.1:
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
+  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
+
+lru.min@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/lru.min/-/lru.min-1.1.2.tgz#01ce1d72cc50c7faf8bd1f809ebf05d4331021eb"
+  integrity sha512-Nv9KddBcQSlQopmBHXSsZVY5xsdlZkdH/Iey0BlcBYggMd4two7cZnKOK9vmy3nY0O5RGH99z1PCeTpPqszUYg==
 
 make-error@^1.1.1:
   version "1.3.6"
@@ -1220,6 +1264,21 @@ ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+mysql2@^3.15.1:
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/mysql2/-/mysql2-3.15.1.tgz#c04e3b944768132618bded85b7cf2fa8397033e0"
+  integrity sha512-WZMIRZstT2MFfouEaDz/AGFnGi1A2GwaDe7XvKTdRJEYiAHbOrh4S3d8KFmQeh11U85G+BFjIvS1Di5alusZsw==
+  dependencies:
+    aws-ssl-profiles "^1.1.1"
+    denque "^2.1.0"
+    generate-function "^2.3.1"
+    iconv-lite "^0.7.0"
+    long "^5.2.1"
+    lru.min "^1.0.0"
+    named-placeholders "^1.1.3"
+    seq-queue "^0.0.5"
+    sqlstring "^2.3.2"
+
 mysql@^2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/mysql/-/mysql-2.18.1.tgz#2254143855c5a8c73825e4522baf2ea021766717"
@@ -1229,6 +1288,13 @@ mysql@^2.18.1:
     readable-stream "2.3.7"
     safe-buffer "5.1.2"
     sqlstring "2.3.1"
+
+named-placeholders@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/named-placeholders/-/named-placeholders-1.1.3.tgz#df595799a36654da55dda6152ba7a137ad1d9351"
+  integrity sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==
+  dependencies:
+    lru-cache "^7.14.1"
 
 negotiator@0.6.3:
   version "0.6.3"
@@ -1406,7 +1472,7 @@ safe-buffer@5.2.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-"safer-buffer@>= 2.1.2 < 3":
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -1436,6 +1502,11 @@ send@0.18.0:
     on-finished "2.4.1"
     range-parser "~1.2.1"
     statuses "2.0.1"
+
+seq-queue@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/seq-queue/-/seq-queue-0.0.5.tgz#d56812e1c017a6e4e7c3e3a37a1da6d78dd3c93e"
+  integrity sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==
 
 serve-static@1.15.0:
   version "1.15.0"
@@ -1493,6 +1564,11 @@ sqlstring@2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.1.tgz#475393ff9e91479aea62dcaf0ca3d14983a7fb40"
   integrity sha512-ooAzh/7dxIG5+uDik1z/Rd1vli0+38izZhGzSa34FwR7IbelPWCCKSNIl8jlL/F7ERvy8CB2jNeM1E9i9mXMAQ==
+
+sqlstring@^2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.3.tgz#2ddc21f03bce2c387ed60680e739922c65751d0c"
+  integrity sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==
 
 stack-utils@^2.0.3:
   version "2.0.6"

--- a/shackUtilities/buildDockerImage.sh
+++ b/shackUtilities/buildDockerImage.sh
@@ -25,7 +25,7 @@ main() {
   buildDockerImage "shack_server"
 
   echo_header "Building Shack Web Image"
-  cd "$SCRIPT_DIR/../shackweb2/" || { echo_error "Failed to change directory"; exit 1; }
+  cd "$SCRIPT_DIR/../shackWeb/" || { echo_error "Failed to change directory"; exit 1; }
   if [ ! -d "./" ]; then
     echo_error "Directory not found."
     exit 1

--- a/shackUtilities/pushDockerImages.sh
+++ b/shackUtilities/pushDockerImages.sh
@@ -1,5 +1,5 @@
-docker tag shack_server registry.digitalocean.com/autoshack/shack_server
-docker push registry.digitalocean.com/autoshack/shack_server
+docker tag shack_server rkennedy11/autoshack:server
+docker push rkennedy11/autoshack:server
 
-docker tag shack_web registry.digitalocean.com/autoshack/shack_web
-docker push registry.digitalocean.com/autoshack/shack_web
+docker tag shack_web rkennedy11/autoshack:web
+docker push rkennedy11/autoshack:web


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces mysql with mysql2 (types and pool config), removes Swagger UI route, and updates Docker build paths and image push targets.
> 
> - **Backend**:
>   - **DB client migration**: Switch `mysql` → `mysql2` in `src/db.ts` with pool options (`waitForConnections`, `connectionLimit`).
>   - **Type updates**: Replace `MysqlError` → `QueryError` in `src/data.ts` and `src/schedule.ts`.
>   - **Dependencies**: Remove `mysql` and add `mysql2` in `shackServer/package.json`.
> - **API**:
>   - Remove Swagger UI setup and docs route from `index.ts`.
> - **DevOps**:
>   - Update web build path in `shackUtilities/buildDockerImage.sh` (`shackweb2` → `shackWeb`).
>   - Change image tagging/pushing in `shackUtilities/pushDockerImages.sh` to `rkennedy11/autoshack:{server,web}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9251ad2f7b3d354cfc6397038415cb45df8cfeb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->